### PR TITLE
RockLib.DistributedTracing.AspNetCore Release 2.1.0-alpha.1

### DIFF
--- a/RockLib.DistributedTracing.AspNetCore/CHANGELOG.md
+++ b/RockLib.DistributedTracing.AspNetCore/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0-alpha.1 - 2022-10-18
+
+#### Added
+- TraceId and SpanId retrieved from Open Telemetry and made available in the CorrelationIdAccessor.
+- OpenTelemetry dependency 1.3.1
+
+#### Changed
+- TraceId value is now used as CorrelationId, when CorelationId is not present, before creating a new value.
+
 ## 2.0.0 - 2022-02-08
 
 #### Added

--- a/RockLib.DistributedTracing.AspNetCore/RockLib.DistributedTracing.AspNetCore.csproj
+++ b/RockLib.DistributedTracing.AspNetCore/RockLib.DistributedTracing.AspNetCore.csproj
@@ -11,10 +11,10 @@
 		<PackageProjectUrl>https://github.com/RockLib/RockLib.DistributedTracing</PackageProjectUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.DistributedTracing/blob/main/RockLib.DistributedTracing.AspNetCore/CHANGELOG.md.</PackageReleaseNotes>
-		<PackageVersion>2.0.0</PackageVersion>
+		<PackageVersion>2.1.0-alpha.1</PackageVersion>
 		<PackageTags>RockLib Distributed-Tracing AspNetCore</PackageTags>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>2.0.0</Version>
+		<Version>2.1.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>


### PR DESCRIPTION
## Description

This releases RockLib.DistributedTracing.AspNetCore version 2.1.0-alpha.1.
---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
