### PR TITLE
Remove .NET 6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,12 +7,12 @@
 		<Authors>Rocket Mortgage</Authors>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0;net48;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.DistributedTracing.AspNetCore.Tests/RockLib.DistributedTracing.AspNetCore.Tests.csproj
+++ b/RockLib.DistributedTracing.AspNetCore.Tests/RockLib.DistributedTracing.AspNetCore.Tests.csproj
@@ -4,16 +4,16 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="Moq" Version="4.20.70" />
-		<PackageReference Include="xunit" Version="2.6.4" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.DistributedTracing.AspNetCore/AspNetCore/HttpContextExtensions.cs
+++ b/RockLib.DistributedTracing.AspNetCore/AspNetCore/HttpContextExtensions.cs
@@ -41,7 +41,7 @@ namespace RockLib.DistributedTracing.AspNetCore
         /// <param name="correlationIdHeader">The name of the correlation id header.</param>
         public static ICorrelationIdAccessor GetCorrelationIdAccessor(this HttpContext httpContext, string correlationIdHeader = CorrelationId)
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(httpContext);
             ArgumentNullException.ThrowIfNull(correlationIdHeader);
 #else
@@ -54,6 +54,7 @@ namespace RockLib.DistributedTracing.AspNetCore
                 throw new ArgumentNullException(nameof(correlationIdHeader));
             }
 #endif
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
             if (!httpContext.Items.TryGetValue(typeof(ICorrelationIdAccessor), out var value)
                || value is not ICorrelationIdAccessor accessor)
             {
@@ -80,6 +81,7 @@ namespace RockLib.DistributedTracing.AspNetCore
 
                 httpContext.Items[typeof(ICorrelationIdAccessor)] = accessor;
             }
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
 
             return accessor;
         }

--- a/RockLib.DistributedTracing.AspNetCore/CHANGELOG.md
+++ b/RockLib.DistributedTracing.AspNetCore/CHANGELOG.md
@@ -5,10 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 4.0.0 - 2024-02-15
+## 4.0.0 - 2025-01-23
 
 #### Changed
 - Removed .NET 6 as a target framework.
+- Updated the following package references:
+	- Microsoft.AspNetCore.Http.Abstractions from 2.2.0 to 2.3.0
+	- Microsoft.Extensions.Options from 8.0.0 to 9.0.0
+	- OpenTelemetry from 1.7.0 to 1.11.1
+	- System.Text.Encodings.Web from 8.0.0 to 9.0.0
 
 ## 3.0.0 - 2024-02-15
 

--- a/RockLib.DistributedTracing.AspNetCore/CHANGELOG.md
+++ b/RockLib.DistributedTracing.AspNetCore/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0 - 2024-02-15
+
+#### Changed
+- Removed .NET 6 as a target framework.
+
 ## 3.0.0 - 2024-02-15
 
 #### Changed

--- a/RockLib.DistributedTracing.AspNetCore/RockLib.DistributedTracing.AspNetCore.csproj
+++ b/RockLib.DistributedTracing.AspNetCore/RockLib.DistributedTracing.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Copyright>Copyright 2024 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<Copyright>Copyright 2025 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<DebugType>Embedded</DebugType>
 		<Description>Defines standard interfaces for distributed tracing and extension methods for HttpContext to access them.</Description>
 		<EmbedUntrackedSources>True</EmbedUntrackedSources>
@@ -11,10 +11,10 @@
 		<PackageProjectUrl>https://github.com/RockLib/RockLib.DistributedTracing</PackageProjectUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.DistributedTracing/blob/main/RockLib.DistributedTracing.AspNetCore/CHANGELOG.md.</PackageReleaseNotes>
-		<PackageVersion>3.0.0</PackageVersion>
+		<PackageVersion>4.0.0</PackageVersion>
 		<PackageTags>RockLib Distributed-Tracing AspNetCore</PackageTags>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.0.0</Version>
+		<Version>4.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -28,10 +28,9 @@
 		<None Include="..\icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="OpenTelemetry" Version="1.7.0" />
-		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
+		<PackageReference Include="OpenTelemetry" Version="1.11.1" />
+		<PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

This removes .NET 6, updates NuGet package references, and bumps the version to 4.0.0

## Type of change: 

4. Breaking change (fix or feature that could cause existing functionality to not work as expected)
